### PR TITLE
Try: Load CSS files automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,17 @@ The `master` branch is just an empty boilerplate: it sets up a plugin that enque
 1. [Fork the repository](https://help.github.com/en/articles/fork-a-repo). 
 2. [Clone](https://help.github.com/en/articles/cloning-a-repository) your fork. If possible, place your local copy in the Plugins folder of your local dev site. Then you'll be able to activate the plugin directly from your WP Admin dashboard (If this isn't possible, follow the instructions above to install the plugin manually after you've edited it).
 3. If you're using Sass, create new SASS stylesheet in the `sass` directory, and run `npm run build` to compile it. Otherwise, just add a new CSS file to the `css` directory. Experiments are expected to use a single css file. 
-4. Add your experiment to the [`$design_experiments` array in `index.php`](https://github.com/WordPress/design-experiments/blob/e81bafab7f4438aa9bee2982e6d2f6363a935224/index.php#L24-L27). This will properly enqueue your new stylesheet and ensure that your experiment shows up on the Plugin's settings page. This takes just a single line of code. An example is commented out in the file:
-	- `stylesheet`: The filename of your experiment's stylesheet, minus the extension. No spaces please.
-	- `Experiment title`: A title for your experiment.
-	- `url/to/experiment`: A URL to an explanation of your experiment. Ideally a GitHub PR or Trac ticket. (Optional)
-5. When your stylesheet is ready, visit `Settings > Design Experiments` and select your stylesheet to activate it and view your changes.
+4. Begin your CSS file with the following code comment, adjusting the values of each field to best describe your experiment (All fields are optional):
+
+	```
+	/*{
+		"title": "Your Experiment Title",
+		"details": "A description of your Experiment",
+		"pr": "https://"
+	}*/
+	```
+
+5. When your stylesheet is ready, visit `Settings > Design Experiments`. Select your experiment to activate it and view your changes.
 6. Once you're ready to share your experiment, [open a PR](https://help.github.com/en/articles/creating-a-pull-request) and share it here. 
 
 ### To compile CSS:

--- a/css/a-sample-experiment.css
+++ b/css/a-sample-experiment.css
@@ -1,4 +1,5 @@
 /*{
+	"title": "A sample experiment that will make everything red",
 	"pr": "https://github.com/WordPress/design-experiments/pull/3",
 	"details": "A test experiment"
 }*/

--- a/css/a-sample-experiment.css
+++ b/css/a-sample-experiment.css
@@ -1,8 +1,0 @@
-/*{
-	"title": "A sample experiment that will make everything red",
-	"pr": "https://github.com/WordPress/design-experiments/pull/3",
-	"details": "A test experiment"
-}*/
-div {
-	background-color:red;
-}

--- a/css/a-sample-experiment.css
+++ b/css/a-sample-experiment.css
@@ -1,0 +1,7 @@
+/*{
+	"pr": "https://github.com/WordPress/design-experiments/pull/3",
+	"details": "A test experiment"
+}*/
+div {
+	background-color:red;
+}

--- a/css/default.css
+++ b/css/default.css
@@ -1,3 +1,5 @@
-/*
- * Admin Styles
- */
+/*{
+	"title": "Default Experiment",
+	"details": "The default plugin stylesheet.",
+	"pr": "https://github.com/WordPress/design-experiments/"
+}*/

--- a/index.php
+++ b/index.php
@@ -71,7 +71,11 @@ class DesignExperiments {
 		);
 		register_setting( 'design-experiments-settings', 'design-experiments-setting', $design_setting_args );
 	}
-	
+
+
+	/**
+	 * Fetch experiment title from the CSS file.
+	 */
 	private function get_title( $experiment_name ) {
 		
 		$default_title = ucfirst( str_replace( '-', ' ', $experiment_name ) );
@@ -95,7 +99,12 @@ class DesignExperiments {
 		return $default_title;
 	}
 
+
+	/**
+	 * Fetch experiment metadata from the CSS file.
+	 */
 	private function output_meta_data ( $experiment_name ) {
+
 		if ( ! array_key_exists( $experiment_name, $this->meta_data ) ) {
 			return false;
 		}
@@ -103,24 +112,25 @@ class DesignExperiments {
 		$experiment_meta_data = $this->meta_data[$experiment_name];
 
 		if ( ! empty( $experiment_meta_data->details ) ) {
-		?>
-		<p>
-			<?php echo esc_html( 
-				$experiment_meta_data->details
-			); ?>
-		</p>
-		<?php
+			?>
+			<p>
+				<?php echo esc_html( 
+					$experiment_meta_data->details
+				); ?>
+			</p>
+			<?php
 		}
 		
 		if ( ! empty( $experiment_meta_data->pr ) ) {
-		?>
-		<a href="<?php echo $experiment_meta_data->pr; ?>">
-			Details
-		</a>
-		<?php
+			?>
+			<p>
+				<a href="<?php echo $experiment_meta_data->pr; ?>"><?php _e( 'Details' ); ?></a>
+			</p>
+			<?php
 		}
 	}
-	
+
+
 	/**
 	 * Build the WP-Admin settings page.
 	 */
@@ -133,14 +143,16 @@ class DesignExperiments {
 			<?php settings_fields( 'design-experiments-settings' ); ?>
 			<?php do_settings_sections( 'design-experiments-settings' ); ?>
 
-				<table class="form-table">
+				<table class="form-table" style="width: auto;">
 					<?php foreach ( $this->design_experiment_css_files as $css_file ) {
 						$experiment_name = basename( $css_file, '.css' ); 
 						$experiment_title = $this->get_title( $experiment_name ); ?>
 						<tr valign="top">
-							<td>
-								<label for="design-experiments-setting">
-									<input name="design-experiments-setting" type="radio" value="<?php echo esc_attr( $experiment_name ); ?>" <?php checked( $experiment_name, get_option( 'design-experiments-setting' ) ); ?> />
+							<td style="vertical-align: top;display: table-cell;">
+								<input name="design-experiments-setting" type="radio" value="<?php echo esc_attr( $experiment_name ); ?>" <?php checked( $experiment_name, get_option( 'design-experiments-setting' ) ); ?> />
+							</td>
+							<td style="display: table-cell;">
+								<label for="design-experiments-setting" style="font-weight: bold">
 									<?php echo esc_html( $experiment_title ); ?>
 								</label>
 								<?php $this->output_meta_data(

--- a/index.php
+++ b/index.php
@@ -11,6 +11,11 @@
 class DesignExperiments {
 
 	function __construct() {
+		
+		// Generate a list of all CSS files
+		$this->design_experiment_css_files = glob( plugin_dir_path( __FILE__ ) . 'css/*.css' );
+
+		// Add admin actions
 		add_action( 'admin_menu', array( $this, 'design_experiments_add_settings_page' ) );
 		add_action( 'admin_init', array( $this, 'design_experiments_settings' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'design_experiments_enqueue_stylesheets' ) );
@@ -18,14 +23,9 @@ class DesignExperiments {
 
 
 	/**
-	 * Register all the experiments. 
+	 * Define a list of all CSS files
 	 */
-	private $design_experiments = array(
-		array( 'default', 'Default plugin stylesheet', 'https://github.com/WordPress/design-experiments' ),
-
-		// To enqueue a new stylesheet, add a line above using the example here as a guide: 
-		// array( 'stylesheet', 'Experiment title', 'url/to/experiment' ),
-	);
+	private $design_experiment_css_files;
 
 
 	/**
@@ -61,15 +61,14 @@ class DesignExperiments {
 			<?php do_settings_sections( 'design-experiments-settings' ); ?>
 
 				<table class="form-table">
-					<?php foreach ( $this->design_experiments as $design_experiment ) { ?>
+					<?php foreach ( $this->design_experiment_css_files as $css_file ) {
+						$experiment_name = basename( $css_file, '.css' ); 
+						$experiment_title = ucfirst( str_replace( '-', ' ', $experiment_name ) ); ?>
 						<tr valign="top">
 							<td>
 								<label for="design-experiments-setting">
-									<input name="design-experiments-setting" type="radio" value="<?php echo esc_attr( $design_experiment[0] ); ?>" <?php checked( $design_experiment[0], get_option( 'design-experiments-setting' ) ); ?> />
-									<?php echo esc_html( $design_experiment[1] ); ?>
-									<?php if ( $design_experiment[2] ) { ?>
-										(<a href="<?php echo esc_url( $design_experiment[2] ); ?>"><?php _e( 'Learn more' ); ?></a>)
-									<?php } ?>
+									<input name="design-experiments-setting" type="radio" value="<?php echo esc_attr( $experiment_name ); ?>" <?php checked( $experiment_name, get_option( 'design-experiments-setting' ) ); ?> />
+									<?php echo esc_html( $experiment_title ); ?>
 								</label>
 							</td>
 						</tr>
@@ -87,13 +86,14 @@ class DesignExperiments {
 	 */
 	function design_experiments_enqueue_stylesheets() {
 
-		foreach ( $this->design_experiments as $design_experiment ) {
+		foreach ( $this->design_experiment_css_files as $css_file ) {
+			$experiment_name = basename( $css_file, '.css' );
+			$experiment_url = plugins_url( 'css/' . basename( $css_file ), __FILE__ );
 
-			if ( get_option( 'design-experiments-setting' ) == $design_experiment[0] ) {
-				wp_register_style( $design_experiment[0], plugins_url( 'css/' . $design_experiment[0] . '.css', __FILE__ ), false, '1.0.0' );
-				wp_enqueue_style( $design_experiment[0] );
+			if ( get_option( 'design-experiments-setting' ) == $experiment_name ) {
+				wp_register_style( $experiment_name , $experiment_url, false, '1.0.0' );
+				wp_enqueue_style( $experiment_name );
 			}
-
 		}
 
 	}

--- a/index.php
+++ b/index.php
@@ -71,6 +71,29 @@ class DesignExperiments {
 		);
 		register_setting( 'design-experiments-settings', 'design-experiments-setting', $design_setting_args );
 	}
+	
+	private function get_title( $experiment_name ) {
+		
+		$default_title = ucfirst( str_replace( '-', ' ', $experiment_name ) );
+		
+		if ( ! array_key_exists( $experiment_name, $this->meta_data ) ) {
+			return $default_title;
+		}
+		
+		$experiment_meta_data = $this->meta_data[$experiment_name];
+		$experiment_has_meta_data = array_key_exists( 
+			$experiment_name, $this->meta_data
+		);
+		$meta_data_has_title = ! empty( $experiment_meta_data->title );
+		
+		if ( $experiment_has_meta_data && $meta_data_has_title ) {
+			return esc_html( 
+				$experiment_meta_data->title
+			);
+		}
+		
+		return $default_title;
+	}
 
 	private function output_meta_data ( $experiment_name ) {
 		if ( ! array_key_exists( $experiment_name, $this->meta_data ) ) {
@@ -113,7 +136,7 @@ class DesignExperiments {
 				<table class="form-table">
 					<?php foreach ( $this->design_experiment_css_files as $css_file ) {
 						$experiment_name = basename( $css_file, '.css' ); 
-						$experiment_title = ucfirst( str_replace( '-', ' ', $experiment_name ) ); ?>
+						$experiment_title = $this->get_title( $experiment_name ); ?>
 						<tr valign="top">
 							<td>
 								<label for="design-experiments-setting">

--- a/sass/default.scss
+++ b/sass/default.scss
@@ -1,3 +1,6 @@
-/*
- * Admin Styles
- */
+/*{
+	"title": "Default Experiment",
+	"details": "The default plugin stylesheet.",
+	"pr": "https://github.com/WordPress/design-experiments/"
+}*/
+


### PR DESCRIPTION
This PR offers an alternate approach to contributing to this repo. Rather than force users to edit `index.php`, this method would automatically create a settings option for each CSS file inside of the plugin's `css` folder. 

This eliminates an extra step to get started, but also removes the ability to link out to a PR for more information + discussion. For now, that removes a lot of context. 

**To test:** 

1. Create a new CSS file in the `css` directory. 
2. Visit `Settings > Design Experiments` and verify that your new stylesheet is listed as an option. The label for the option should be your filename, with `-` converted to spaces. 
3. Select your stylesheet as the active option and verify that it loads in correctly. 