### PR TITLE
Try Gutenberg-like settings pages

### DIFF
--- a/assets/dropdown-arrow.svg
+++ b/assets/dropdown-arrow.svg
@@ -1,0 +1,1 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="38" height="38" fill="white"/><path d="M19 22L15 16H23L19 22Z" fill="black"/></svg>

--- a/css/gutenberg-form-fields.css
+++ b/css/gutenberg-form-fields.css
@@ -1,13 +1,16 @@
-/*
- * Gutenberg Forms
- */
+/*{
+	"title": "Gutenberg Form Fields",
+	"details": "An experiment to see how Gutenberg form field styles might look in WP-Admin.",
+	"pr": "https://github.com/WordPress/design-experiments/pull/5"
+}*/
+
 body.options-general-php,
 body.options-writing-php,
 body.options-reading-php,
 body.options-discussion-php,
 body.options-media-php,
 body.options-permalink-php {
-  background: white;
+	background: white;
 }
 
 body.options-general-php .wrap > h1,
@@ -16,8 +19,8 @@ body.options-reading-php .wrap > h1,
 body.options-discussion-php .wrap > h1,
 body.options-media-php .wrap > h1,
 body.options-permalink-php .wrap > h1 {
-  max-width: 500px;
-  margin: 64px auto 0;
+	max-width: 500px;
+	margin: 64px auto 0;
 }
 
 body.options-general-php .wrap > form,
@@ -26,8 +29,8 @@ body.options-reading-php .wrap > form,
 body.options-discussion-php .wrap > form,
 body.options-media-php .wrap > form,
 body.options-permalink-php .wrap > form {
-  max-width: 500px;
-  margin: 0 auto;
+	max-width: 500px;
+	margin: 0 auto;
 }
 
 body.options-general-php .wrap > form tr,
@@ -36,8 +39,8 @@ body.options-reading-php .wrap > form tr,
 body.options-discussion-php .wrap > form tr,
 body.options-media-php .wrap > form tr,
 body.options-permalink-php .wrap > form tr {
-  flex-direction: column;
-  display: flex;
+	flex-direction: column;
+	display: flex;
 }
 
 body.options-general-php .wrap > form td,
@@ -46,7 +49,7 @@ body.options-reading-php .wrap > form td,
 body.options-discussion-php .wrap > form td,
 body.options-media-php .wrap > form td,
 body.options-permalink-php .wrap > form td {
-  padding: 0;
+	padding: 0;
 }
 
 body.options-general-php .wrap > form h2,
@@ -55,7 +58,7 @@ body.options-reading-php .wrap > form h2,
 body.options-discussion-php .wrap > form h2,
 body.options-media-php .wrap > form h2,
 body.options-permalink-php .wrap > form h2 {
-  margin-top: 48px;
+	margin-top: 48px;
 }
 
 body.options-general-php .wrap > form .form-table,
@@ -82,7 +85,7 @@ body.options-permalink-php .wrap > form .form-table,
 body.options-permalink-php .wrap > form .form-table td,
 body.options-permalink-php .wrap > form .form-table td p,
 body.options-permalink-php .wrap > form .form-table th {
-  font-size: 13px;
+	font-size: 13px;
 }
 
 body.options-general-php .wrap > form .form-table th,
@@ -91,8 +94,8 @@ body.options-reading-php .wrap > form .form-table th,
 body.options-discussion-php .wrap > form .form-table th,
 body.options-media-php .wrap > form .form-table th,
 body.options-permalink-php .wrap > form .form-table th {
-  padding-bottom: 8px;
-  font-weight: normal;
+	padding-bottom: 8px;
+	font-weight: normal;
 }
 
 body.options-general-php .wrap > form input[type="text"],
@@ -119,17 +122,17 @@ body.options-permalink-php .wrap > form input[type="text"],
 body.options-permalink-php .wrap > form input[type="url"],
 body.options-permalink-php .wrap > form input[type="email"],
 body.options-permalink-php .wrap > form input[type="number"] {
-  width: 100%;
-  max-width: 100%;
-  padding: 10px;
-  min-height: 24px;
-  background: inherit;
-  font-size: 13px;
-  color: #23282d;
-  box-shadow: none;
-  transition: box-shadow 0.1s linear;
-  border-radius: 4px;
-  border: 1px solid #8d96a0;
+	width: 100%;
+	max-width: 100%;
+	padding: 10px;
+	min-height: 24px;
+	background: inherit;
+	font-size: 13px;
+	color: #23282d;
+	box-shadow: none;
+	transition: box-shadow 0.1s linear;
+	border-radius: 4px;
+	border: 1px solid #8d96a0;
 }
 
 body.options-general-php .wrap > form input[type="text"]:focus,
@@ -156,9 +159,9 @@ body.options-permalink-php .wrap > form input[type="text"]:focus,
 body.options-permalink-php .wrap > form input[type="url"]:focus,
 body.options-permalink-php .wrap > form input[type="email"]:focus,
 body.options-permalink-php .wrap > form input[type="number"]:focus {
-  color: #191e23;
-  border-color: #007cba;
-  box-shadow: 0 0 0 1px #007cba;
+	color: #191e23;
+	border-color: #007cba;
+	box-shadow: 0 0 0 1px #007cba;
 }
 
 body.options-general-php .wrap > form input[type="number"].small-text,
@@ -167,7 +170,7 @@ body.options-reading-php .wrap > form input[type="number"].small-text,
 body.options-discussion-php .wrap > form input[type="number"].small-text,
 body.options-media-php .wrap > form input[type="number"].small-text,
 body.options-permalink-php .wrap > form input[type="number"].small-text {
-  width: 65px;
+	width: 65px;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"],
@@ -182,9 +185,9 @@ body.options-media-php .wrap > form input[type="checkbox"],
 body.options-media-php .wrap > form input[type="radio"],
 body.options-permalink-php .wrap > form input[type="checkbox"],
 body.options-permalink-php .wrap > form input[type="radio"] {
-  border: 2px solid #6c7781;
-  margin-right: 8px;
-  transition: none;
+	border: 2px solid #6c7781;
+	margin-right: 8px;
+	transition: none;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:focus,
@@ -199,8 +202,8 @@ body.options-media-php .wrap > form input[type="checkbox"]:focus,
 body.options-media-php .wrap > form input[type="radio"]:focus,
 body.options-permalink-php .wrap > form input[type="checkbox"]:focus,
 body.options-permalink-php .wrap > form input[type="radio"]:focus {
-  border-color: #6c7781;
-  box-shadow: 0 0 0 1px #6c7781;
+	border-color: #6c7781;
+	box-shadow: 0 0 0 1px #6c7781;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:checked,
@@ -215,8 +218,8 @@ body.options-media-php .wrap > form input[type="checkbox"]:checked,
 body.options-media-php .wrap > form input[type="radio"]:checked,
 body.options-permalink-php .wrap > form input[type="checkbox"]:checked,
 body.options-permalink-php .wrap > form input[type="radio"]:checked {
-  background: #11a0d2;
-  border-color: #11a0d2;
+	background: #11a0d2;
+	border-color: #11a0d2;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:checked:focus,
@@ -231,7 +234,7 @@ body.options-media-php .wrap > form input[type="checkbox"]:checked:focus,
 body.options-media-php .wrap > form input[type="radio"]:checked:focus,
 body.options-permalink-php .wrap > form input[type="checkbox"]:checked:focus,
 body.options-permalink-php .wrap > form input[type="radio"]:checked:focus {
-  box-shadow: 0 0 0 2px #555d66;
+	box-shadow: 0 0 0 2px #555d66;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"],
@@ -240,7 +243,7 @@ body.options-reading-php .wrap > form input[type="checkbox"],
 body.options-discussion-php .wrap > form input[type="checkbox"],
 body.options-media-php .wrap > form input[type="checkbox"],
 body.options-permalink-php .wrap > form input[type="checkbox"] {
-  border-radius: 4px;
+	border-radius: 4px;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
@@ -254,24 +257,24 @@ body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
 body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
 body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
 body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
-  margin: -3px -5px;
-  color: white;
+	margin: -3px -5px;
+	color: white;
 }
 
 @media all and (min-width: 782px) {
-  body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-  body.options-writing-php .wrap > form input[type="checkbox"]:checked::before,
-  body.options-writing-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-  body.options-reading-php .wrap > form input[type="checkbox"]:checked::before,
-  body.options-reading-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-  body.options-discussion-php .wrap > form input[type="checkbox"]:checked::before,
-  body.options-discussion-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-  body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
-  body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-  body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
-  body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
-    margin: -4px 0 0 -5px;
-  }
+	body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+	body.options-writing-php .wrap > form input[type="checkbox"]:checked::before,
+	body.options-writing-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+	body.options-reading-php .wrap > form input[type="checkbox"]:checked::before,
+	body.options-reading-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+	body.options-discussion-php .wrap > form input[type="checkbox"]:checked::before,
+	body.options-discussion-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+	body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
+	body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+	body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
+	body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
+	margin: -4px 0 0 -5px;
+	}
 }
 
 body.options-general-php .wrap > form input[type="radio"],
@@ -280,7 +283,7 @@ body.options-reading-php .wrap > form input[type="radio"],
 body.options-discussion-php .wrap > form input[type="radio"],
 body.options-media-php .wrap > form input[type="radio"],
 body.options-permalink-php .wrap > form input[type="radio"] {
-  border-radius: 8px;
+	border-radius: 8px;
 }
 
 body.options-general-php .wrap > form input[type="radio"]:checked::before,
@@ -289,19 +292,19 @@ body.options-reading-php .wrap > form input[type="radio"]:checked::before,
 body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
 body.options-media-php .wrap > form input[type="radio"]:checked::before,
 body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
-  margin: 6px 0 0 6px;
-  background-color: white;
+	margin: 6px 0 0 6px;
+	background-color: white;
 }
 
 @media all and (min-width: 782px) {
-  body.options-general-php .wrap > form input[type="radio"]:checked::before,
-  body.options-writing-php .wrap > form input[type="radio"]:checked::before,
-  body.options-reading-php .wrap > form input[type="radio"]:checked::before,
-  body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
-  body.options-media-php .wrap > form input[type="radio"]:checked::before,
-  body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
-    margin: 3px 0 0 3px;
-  }
+	body.options-general-php .wrap > form input[type="radio"]:checked::before,
+	body.options-writing-php .wrap > form input[type="radio"]:checked::before,
+	body.options-reading-php .wrap > form input[type="radio"]:checked::before,
+	body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
+	body.options-media-php .wrap > form input[type="radio"]:checked::before,
+	body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
+	margin: 3px 0 0 3px;
+	}
 }
 
 body.options-general-php .wrap > form select,
@@ -310,15 +313,15 @@ body.options-reading-php .wrap > form select,
 body.options-discussion-php .wrap > form select,
 body.options-media-php .wrap > form select,
 body.options-permalink-php .wrap > form select {
-  -webkit-appearance: none;
-  background: url("../assets/dropdown-arrow.svg") center right no-repeat;
-  padding: 4px 32px 4px 10px;
-  height: auto;
-  box-shadow: 0 0 0 transparent;
-  transition: box-shadow 0.1s linear;
-  border-radius: 4px;
-  border: 1px solid #8d96a0;
-  font-size: 13px;
+	-webkit-appearance: none;
+	background: url("../assets/dropdown-arrow.svg") center right no-repeat;
+	padding: 4px 32px 4px 10px;
+	height: auto;
+	box-shadow: 0 0 0 transparent;
+	transition: box-shadow 0.1s linear;
+	border-radius: 4px;
+	border: 1px solid #8d96a0;
+	font-size: 13px;
 }
 
 body.options-general-php .wrap > form select:disabled,
@@ -327,7 +330,7 @@ body.options-reading-php .wrap > form select:disabled,
 body.options-discussion-php .wrap > form select:disabled,
 body.options-media-php .wrap > form select:disabled,
 body.options-permalink-php .wrap > form select:disabled {
-  border: 1px solid #ccd0d4;
+	border: 1px solid #ccd0d4;
 }
 
 body.options-general-php .wrap > form select:not(:disabled):hover,
@@ -336,11 +339,11 @@ body.options-reading-php .wrap > form select:not(:disabled):hover,
 body.options-discussion-php .wrap > form select:not(:disabled):hover,
 body.options-media-php .wrap > form select:not(:disabled):hover,
 body.options-permalink-php .wrap > form select:not(:disabled):hover {
-  cursor: pointer;
-  background-color: #fafafa;
-  border-color: #999;
-  box-shadow: inset 0 -1px 0 #999;
-  color: #23282d;
+	cursor: pointer;
+	background-color: #fafafa;
+	border-color: #999;
+	box-shadow: inset 0 -1px 0 #999;
+	color: #23282d;
 }
 
 body.options-general-php .wrap > form input[type="submit"].button-primary,
@@ -349,36 +352,36 @@ body.options-reading-php .wrap > form input[type="submit"].button-primary,
 body.options-discussion-php .wrap > form input[type="submit"].button-primary,
 body.options-media-php .wrap > form input[type="submit"].button-primary,
 body.options-permalink-php .wrap > form input[type="submit"].button-primary {
-  padding: 6px 12px;
-  height: auto;
+	padding: 6px 12px;
+	height: auto;
 }
 
 body.options-writing-php #default_post_format {
-  padding-right: 32px;
+	padding-right: 32px;
 }
 
 body.options-writing-php #mailserver_url {
-  width: 25em;
+	width: 25em;
 }
 
 body.options-writing-php #mailserver_url + label {
-  margin-left: 12px;
+	margin-left: 12px;
 }
 
 body.options-writing-php #mailserver_port {
-  width: 50px;
+	width: 50px;
 }
 
 body.options-permalink-php code {
-  display: inline-block;
-  margin-top: 4px;
+	display: inline-block;
+	margin-top: 4px;
 }
 
 body.options-permalink-php p > code {
-  font-size: 12px;
+	font-size: 12px;
 }
 
 body.options-permalink-php #permalink_structure {
-  margin-top: 16px;
-  margin-bottom: 8px;
+	margin-top: 16px;
+	margin-bottom: 8px;
 }

--- a/css/gutenberg-form-fields.css
+++ b/css/gutenberg-form-fields.css
@@ -3,14 +3,13 @@
 	"details": "An experiment to see how Gutenberg form field styles might look in WP-Admin.",
 	"pr": "https://github.com/WordPress/design-experiments/pull/5"
 }*/
-
 body.options-general-php,
 body.options-writing-php,
 body.options-reading-php,
 body.options-discussion-php,
 body.options-media-php,
 body.options-permalink-php {
-	background: white;
+  background: white;
 }
 
 body.options-general-php .wrap > h1,
@@ -19,8 +18,8 @@ body.options-reading-php .wrap > h1,
 body.options-discussion-php .wrap > h1,
 body.options-media-php .wrap > h1,
 body.options-permalink-php .wrap > h1 {
-	max-width: 500px;
-	margin: 64px auto 0;
+  max-width: 500px;
+  margin: 64px auto 0;
 }
 
 body.options-general-php .wrap > form,
@@ -29,8 +28,8 @@ body.options-reading-php .wrap > form,
 body.options-discussion-php .wrap > form,
 body.options-media-php .wrap > form,
 body.options-permalink-php .wrap > form {
-	max-width: 500px;
-	margin: 0 auto;
+  max-width: 500px;
+  margin: 0 auto;
 }
 
 body.options-general-php .wrap > form tr,
@@ -39,8 +38,8 @@ body.options-reading-php .wrap > form tr,
 body.options-discussion-php .wrap > form tr,
 body.options-media-php .wrap > form tr,
 body.options-permalink-php .wrap > form tr {
-	flex-direction: column;
-	display: flex;
+  flex-direction: column;
+  display: flex;
 }
 
 body.options-general-php .wrap > form td,
@@ -49,7 +48,7 @@ body.options-reading-php .wrap > form td,
 body.options-discussion-php .wrap > form td,
 body.options-media-php .wrap > form td,
 body.options-permalink-php .wrap > form td {
-	padding: 0;
+  padding: 0;
 }
 
 body.options-general-php .wrap > form h2,
@@ -58,7 +57,7 @@ body.options-reading-php .wrap > form h2,
 body.options-discussion-php .wrap > form h2,
 body.options-media-php .wrap > form h2,
 body.options-permalink-php .wrap > form h2 {
-	margin-top: 48px;
+  margin-top: 48px;
 }
 
 body.options-general-php .wrap > form .form-table,
@@ -85,7 +84,7 @@ body.options-permalink-php .wrap > form .form-table,
 body.options-permalink-php .wrap > form .form-table td,
 body.options-permalink-php .wrap > form .form-table td p,
 body.options-permalink-php .wrap > form .form-table th {
-	font-size: 13px;
+  font-size: 13px;
 }
 
 body.options-general-php .wrap > form .form-table th,
@@ -94,8 +93,8 @@ body.options-reading-php .wrap > form .form-table th,
 body.options-discussion-php .wrap > form .form-table th,
 body.options-media-php .wrap > form .form-table th,
 body.options-permalink-php .wrap > form .form-table th {
-	padding-bottom: 8px;
-	font-weight: normal;
+  padding-bottom: 8px;
+  font-weight: normal;
 }
 
 body.options-general-php .wrap > form input[type="text"],
@@ -122,17 +121,17 @@ body.options-permalink-php .wrap > form input[type="text"],
 body.options-permalink-php .wrap > form input[type="url"],
 body.options-permalink-php .wrap > form input[type="email"],
 body.options-permalink-php .wrap > form input[type="number"] {
-	width: 100%;
-	max-width: 100%;
-	padding: 10px;
-	min-height: 24px;
-	background: inherit;
-	font-size: 13px;
-	color: #23282d;
-	box-shadow: none;
-	transition: box-shadow 0.1s linear;
-	border-radius: 4px;
-	border: 1px solid #8d96a0;
+  width: 100%;
+  max-width: 100%;
+  padding: 10px;
+  min-height: 24px;
+  background: inherit;
+  font-size: 13px;
+  color: #23282d;
+  box-shadow: none;
+  transition: box-shadow 0.1s linear;
+  border-radius: 4px;
+  border: 1px solid #8d96a0;
 }
 
 body.options-general-php .wrap > form input[type="text"]:focus,
@@ -159,9 +158,9 @@ body.options-permalink-php .wrap > form input[type="text"]:focus,
 body.options-permalink-php .wrap > form input[type="url"]:focus,
 body.options-permalink-php .wrap > form input[type="email"]:focus,
 body.options-permalink-php .wrap > form input[type="number"]:focus {
-	color: #191e23;
-	border-color: #007cba;
-	box-shadow: 0 0 0 1px #007cba;
+  color: #191e23;
+  border-color: #007cba;
+  box-shadow: 0 0 0 1px #007cba;
 }
 
 body.options-general-php .wrap > form input[type="number"].small-text,
@@ -170,7 +169,7 @@ body.options-reading-php .wrap > form input[type="number"].small-text,
 body.options-discussion-php .wrap > form input[type="number"].small-text,
 body.options-media-php .wrap > form input[type="number"].small-text,
 body.options-permalink-php .wrap > form input[type="number"].small-text {
-	width: 65px;
+  width: 65px;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"],
@@ -185,9 +184,9 @@ body.options-media-php .wrap > form input[type="checkbox"],
 body.options-media-php .wrap > form input[type="radio"],
 body.options-permalink-php .wrap > form input[type="checkbox"],
 body.options-permalink-php .wrap > form input[type="radio"] {
-	border: 2px solid #6c7781;
-	margin-right: 8px;
-	transition: none;
+  border: 2px solid #6c7781;
+  margin-right: 8px;
+  transition: none;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:focus,
@@ -202,8 +201,8 @@ body.options-media-php .wrap > form input[type="checkbox"]:focus,
 body.options-media-php .wrap > form input[type="radio"]:focus,
 body.options-permalink-php .wrap > form input[type="checkbox"]:focus,
 body.options-permalink-php .wrap > form input[type="radio"]:focus {
-	border-color: #6c7781;
-	box-shadow: 0 0 0 1px #6c7781;
+  border-color: #6c7781;
+  box-shadow: 0 0 0 1px #6c7781;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:checked,
@@ -218,8 +217,8 @@ body.options-media-php .wrap > form input[type="checkbox"]:checked,
 body.options-media-php .wrap > form input[type="radio"]:checked,
 body.options-permalink-php .wrap > form input[type="checkbox"]:checked,
 body.options-permalink-php .wrap > form input[type="radio"]:checked {
-	background: #11a0d2;
-	border-color: #11a0d2;
+  background: #11a0d2;
+  border-color: #11a0d2;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:checked:focus,
@@ -234,7 +233,7 @@ body.options-media-php .wrap > form input[type="checkbox"]:checked:focus,
 body.options-media-php .wrap > form input[type="radio"]:checked:focus,
 body.options-permalink-php .wrap > form input[type="checkbox"]:checked:focus,
 body.options-permalink-php .wrap > form input[type="radio"]:checked:focus {
-	box-shadow: 0 0 0 2px #555d66;
+  box-shadow: 0 0 0 2px #555d66;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"],
@@ -243,7 +242,7 @@ body.options-reading-php .wrap > form input[type="checkbox"],
 body.options-discussion-php .wrap > form input[type="checkbox"],
 body.options-media-php .wrap > form input[type="checkbox"],
 body.options-permalink-php .wrap > form input[type="checkbox"] {
-	border-radius: 4px;
+  border-radius: 4px;
 }
 
 body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
@@ -257,24 +256,24 @@ body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
 body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
 body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
 body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
-	margin: -3px -5px;
-	color: white;
+  margin: -3px -5px;
+  color: white;
 }
 
 @media all and (min-width: 782px) {
-	body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-	body.options-writing-php .wrap > form input[type="checkbox"]:checked::before,
-	body.options-writing-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-	body.options-reading-php .wrap > form input[type="checkbox"]:checked::before,
-	body.options-reading-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-	body.options-discussion-php .wrap > form input[type="checkbox"]:checked::before,
-	body.options-discussion-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-	body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
-	body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
-	body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
-	body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
-	margin: -4px 0 0 -5px;
-	}
+  body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-writing-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-writing-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-reading-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-reading-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-discussion-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-discussion-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
+    margin: -4px 0 0 -5px;
+  }
 }
 
 body.options-general-php .wrap > form input[type="radio"],
@@ -283,7 +282,7 @@ body.options-reading-php .wrap > form input[type="radio"],
 body.options-discussion-php .wrap > form input[type="radio"],
 body.options-media-php .wrap > form input[type="radio"],
 body.options-permalink-php .wrap > form input[type="radio"] {
-	border-radius: 8px;
+  border-radius: 8px;
 }
 
 body.options-general-php .wrap > form input[type="radio"]:checked::before,
@@ -292,19 +291,19 @@ body.options-reading-php .wrap > form input[type="radio"]:checked::before,
 body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
 body.options-media-php .wrap > form input[type="radio"]:checked::before,
 body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
-	margin: 6px 0 0 6px;
-	background-color: white;
+  margin: 6px 0 0 6px;
+  background-color: white;
 }
 
 @media all and (min-width: 782px) {
-	body.options-general-php .wrap > form input[type="radio"]:checked::before,
-	body.options-writing-php .wrap > form input[type="radio"]:checked::before,
-	body.options-reading-php .wrap > form input[type="radio"]:checked::before,
-	body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
-	body.options-media-php .wrap > form input[type="radio"]:checked::before,
-	body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
-	margin: 3px 0 0 3px;
-	}
+  body.options-general-php .wrap > form input[type="radio"]:checked::before,
+  body.options-writing-php .wrap > form input[type="radio"]:checked::before,
+  body.options-reading-php .wrap > form input[type="radio"]:checked::before,
+  body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
+  body.options-media-php .wrap > form input[type="radio"]:checked::before,
+  body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
+    margin: 3px 0 0 3px;
+  }
 }
 
 body.options-general-php .wrap > form select,
@@ -313,15 +312,15 @@ body.options-reading-php .wrap > form select,
 body.options-discussion-php .wrap > form select,
 body.options-media-php .wrap > form select,
 body.options-permalink-php .wrap > form select {
-	-webkit-appearance: none;
-	background: url("../assets/dropdown-arrow.svg") center right no-repeat;
-	padding: 4px 32px 4px 10px;
-	height: auto;
-	box-shadow: 0 0 0 transparent;
-	transition: box-shadow 0.1s linear;
-	border-radius: 4px;
-	border: 1px solid #8d96a0;
-	font-size: 13px;
+  -webkit-appearance: none;
+  background: url("../assets/dropdown-arrow.svg") center right no-repeat;
+  padding: 4px 32px 4px 10px;
+  height: auto;
+  box-shadow: 0 0 0 transparent;
+  transition: box-shadow 0.1s linear;
+  border-radius: 4px;
+  border: 1px solid #8d96a0;
+  font-size: 13px;
 }
 
 body.options-general-php .wrap > form select:disabled,
@@ -330,7 +329,7 @@ body.options-reading-php .wrap > form select:disabled,
 body.options-discussion-php .wrap > form select:disabled,
 body.options-media-php .wrap > form select:disabled,
 body.options-permalink-php .wrap > form select:disabled {
-	border: 1px solid #ccd0d4;
+  border: 1px solid #ccd0d4;
 }
 
 body.options-general-php .wrap > form select:not(:disabled):hover,
@@ -339,11 +338,11 @@ body.options-reading-php .wrap > form select:not(:disabled):hover,
 body.options-discussion-php .wrap > form select:not(:disabled):hover,
 body.options-media-php .wrap > form select:not(:disabled):hover,
 body.options-permalink-php .wrap > form select:not(:disabled):hover {
-	cursor: pointer;
-	background-color: #fafafa;
-	border-color: #999;
-	box-shadow: inset 0 -1px 0 #999;
-	color: #23282d;
+  cursor: pointer;
+  background-color: #fafafa;
+  border-color: #999;
+  box-shadow: inset 0 -1px 0 #999;
+  color: #23282d;
 }
 
 body.options-general-php .wrap > form input[type="submit"].button-primary,
@@ -352,36 +351,36 @@ body.options-reading-php .wrap > form input[type="submit"].button-primary,
 body.options-discussion-php .wrap > form input[type="submit"].button-primary,
 body.options-media-php .wrap > form input[type="submit"].button-primary,
 body.options-permalink-php .wrap > form input[type="submit"].button-primary {
-	padding: 6px 12px;
-	height: auto;
+  padding: 6px 12px;
+  height: auto;
 }
 
 body.options-writing-php #default_post_format {
-	padding-right: 32px;
+  padding-right: 32px;
 }
 
 body.options-writing-php #mailserver_url {
-	width: 25em;
+  width: 25em;
 }
 
 body.options-writing-php #mailserver_url + label {
-	margin-left: 12px;
+  margin-left: 12px;
 }
 
 body.options-writing-php #mailserver_port {
-	width: 50px;
+  width: 50px;
 }
 
 body.options-permalink-php code {
-	display: inline-block;
-	margin-top: 4px;
+  display: inline-block;
+  margin-top: 4px;
 }
 
 body.options-permalink-php p > code {
-	font-size: 12px;
+  font-size: 12px;
 }
 
 body.options-permalink-php #permalink_structure {
-	margin-top: 16px;
-	margin-bottom: 8px;
+  margin-top: 16px;
+  margin-bottom: 8px;
 }

--- a/css/gutenberg-form-fields.css
+++ b/css/gutenberg-form-fields.css
@@ -1,8 +1,8 @@
-/*{
-	"title": "Gutenberg Form Fields",
-	"details": "An experiment to see how Gutenberg form field styles might look in WP-Admin.",
-	"pr": "https://github.com/WordPress/design-experiments/pull/5"
-}*/
+/*
+	Title: Gutenberg Form Fields
+	Description: An experiment to see how Gutenberg form field styles might look in WP-Admin.
+	PR: https://github.com/WordPress/design-experiments/pull/5
+*/
 body.options-general-php,
 body.options-writing-php,
 body.options-reading-php,

--- a/css/gutenberg-form-fields.css
+++ b/css/gutenberg-form-fields.css
@@ -1,7 +1,7 @@
 /*
-	Title: Gutenberg Form Fields
-	Description: An experiment to see how Gutenberg form field styles might look in WP-Admin.
-	PR: https://github.com/WordPress/design-experiments/pull/5
+Title: Gutenberg Form Fields
+Description: An experiment to see how Gutenberg form field styles might look in WP-Admin.
+PR: https://github.com/WordPress/design-experiments/pull/5
 */
 body.options-general-php,
 body.options-writing-php,

--- a/css/gutenberg-form-fields.css
+++ b/css/gutenberg-form-fields.css
@@ -1,0 +1,384 @@
+/*
+ * Gutenberg Forms
+ */
+body.options-general-php,
+body.options-writing-php,
+body.options-reading-php,
+body.options-discussion-php,
+body.options-media-php,
+body.options-permalink-php {
+  background: white;
+}
+
+body.options-general-php .wrap > h1,
+body.options-writing-php .wrap > h1,
+body.options-reading-php .wrap > h1,
+body.options-discussion-php .wrap > h1,
+body.options-media-php .wrap > h1,
+body.options-permalink-php .wrap > h1 {
+  max-width: 500px;
+  margin: 64px auto 0;
+}
+
+body.options-general-php .wrap > form,
+body.options-writing-php .wrap > form,
+body.options-reading-php .wrap > form,
+body.options-discussion-php .wrap > form,
+body.options-media-php .wrap > form,
+body.options-permalink-php .wrap > form {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+body.options-general-php .wrap > form tr,
+body.options-writing-php .wrap > form tr,
+body.options-reading-php .wrap > form tr,
+body.options-discussion-php .wrap > form tr,
+body.options-media-php .wrap > form tr,
+body.options-permalink-php .wrap > form tr {
+  flex-direction: column;
+  display: flex;
+}
+
+body.options-general-php .wrap > form td,
+body.options-writing-php .wrap > form td,
+body.options-reading-php .wrap > form td,
+body.options-discussion-php .wrap > form td,
+body.options-media-php .wrap > form td,
+body.options-permalink-php .wrap > form td {
+  padding: 0;
+}
+
+body.options-general-php .wrap > form h2,
+body.options-writing-php .wrap > form h2,
+body.options-reading-php .wrap > form h2,
+body.options-discussion-php .wrap > form h2,
+body.options-media-php .wrap > form h2,
+body.options-permalink-php .wrap > form h2 {
+  margin-top: 48px;
+}
+
+body.options-general-php .wrap > form .form-table,
+body.options-general-php .wrap > form .form-table td,
+body.options-general-php .wrap > form .form-table td p,
+body.options-general-php .wrap > form .form-table th,
+body.options-writing-php .wrap > form .form-table,
+body.options-writing-php .wrap > form .form-table td,
+body.options-writing-php .wrap > form .form-table td p,
+body.options-writing-php .wrap > form .form-table th,
+body.options-reading-php .wrap > form .form-table,
+body.options-reading-php .wrap > form .form-table td,
+body.options-reading-php .wrap > form .form-table td p,
+body.options-reading-php .wrap > form .form-table th,
+body.options-discussion-php .wrap > form .form-table,
+body.options-discussion-php .wrap > form .form-table td,
+body.options-discussion-php .wrap > form .form-table td p,
+body.options-discussion-php .wrap > form .form-table th,
+body.options-media-php .wrap > form .form-table,
+body.options-media-php .wrap > form .form-table td,
+body.options-media-php .wrap > form .form-table td p,
+body.options-media-php .wrap > form .form-table th,
+body.options-permalink-php .wrap > form .form-table,
+body.options-permalink-php .wrap > form .form-table td,
+body.options-permalink-php .wrap > form .form-table td p,
+body.options-permalink-php .wrap > form .form-table th {
+  font-size: 13px;
+}
+
+body.options-general-php .wrap > form .form-table th,
+body.options-writing-php .wrap > form .form-table th,
+body.options-reading-php .wrap > form .form-table th,
+body.options-discussion-php .wrap > form .form-table th,
+body.options-media-php .wrap > form .form-table th,
+body.options-permalink-php .wrap > form .form-table th {
+  padding-bottom: 8px;
+  font-weight: normal;
+}
+
+body.options-general-php .wrap > form input[type="text"],
+body.options-general-php .wrap > form input[type="url"],
+body.options-general-php .wrap > form input[type="email"],
+body.options-general-php .wrap > form input[type="number"],
+body.options-writing-php .wrap > form input[type="text"],
+body.options-writing-php .wrap > form input[type="url"],
+body.options-writing-php .wrap > form input[type="email"],
+body.options-writing-php .wrap > form input[type="number"],
+body.options-reading-php .wrap > form input[type="text"],
+body.options-reading-php .wrap > form input[type="url"],
+body.options-reading-php .wrap > form input[type="email"],
+body.options-reading-php .wrap > form input[type="number"],
+body.options-discussion-php .wrap > form input[type="text"],
+body.options-discussion-php .wrap > form input[type="url"],
+body.options-discussion-php .wrap > form input[type="email"],
+body.options-discussion-php .wrap > form input[type="number"],
+body.options-media-php .wrap > form input[type="text"],
+body.options-media-php .wrap > form input[type="url"],
+body.options-media-php .wrap > form input[type="email"],
+body.options-media-php .wrap > form input[type="number"],
+body.options-permalink-php .wrap > form input[type="text"],
+body.options-permalink-php .wrap > form input[type="url"],
+body.options-permalink-php .wrap > form input[type="email"],
+body.options-permalink-php .wrap > form input[type="number"] {
+  width: 100%;
+  max-width: 100%;
+  padding: 10px;
+  min-height: 24px;
+  background: inherit;
+  font-size: 13px;
+  color: #23282d;
+  box-shadow: none;
+  transition: box-shadow 0.1s linear;
+  border-radius: 4px;
+  border: 1px solid #8d96a0;
+}
+
+body.options-general-php .wrap > form input[type="text"]:focus,
+body.options-general-php .wrap > form input[type="url"]:focus,
+body.options-general-php .wrap > form input[type="email"]:focus,
+body.options-general-php .wrap > form input[type="number"]:focus,
+body.options-writing-php .wrap > form input[type="text"]:focus,
+body.options-writing-php .wrap > form input[type="url"]:focus,
+body.options-writing-php .wrap > form input[type="email"]:focus,
+body.options-writing-php .wrap > form input[type="number"]:focus,
+body.options-reading-php .wrap > form input[type="text"]:focus,
+body.options-reading-php .wrap > form input[type="url"]:focus,
+body.options-reading-php .wrap > form input[type="email"]:focus,
+body.options-reading-php .wrap > form input[type="number"]:focus,
+body.options-discussion-php .wrap > form input[type="text"]:focus,
+body.options-discussion-php .wrap > form input[type="url"]:focus,
+body.options-discussion-php .wrap > form input[type="email"]:focus,
+body.options-discussion-php .wrap > form input[type="number"]:focus,
+body.options-media-php .wrap > form input[type="text"]:focus,
+body.options-media-php .wrap > form input[type="url"]:focus,
+body.options-media-php .wrap > form input[type="email"]:focus,
+body.options-media-php .wrap > form input[type="number"]:focus,
+body.options-permalink-php .wrap > form input[type="text"]:focus,
+body.options-permalink-php .wrap > form input[type="url"]:focus,
+body.options-permalink-php .wrap > form input[type="email"]:focus,
+body.options-permalink-php .wrap > form input[type="number"]:focus {
+  color: #191e23;
+  border-color: #007cba;
+  box-shadow: 0 0 0 1px #007cba;
+}
+
+body.options-general-php .wrap > form input[type="number"].small-text,
+body.options-writing-php .wrap > form input[type="number"].small-text,
+body.options-reading-php .wrap > form input[type="number"].small-text,
+body.options-discussion-php .wrap > form input[type="number"].small-text,
+body.options-media-php .wrap > form input[type="number"].small-text,
+body.options-permalink-php .wrap > form input[type="number"].small-text {
+  width: 65px;
+}
+
+body.options-general-php .wrap > form input[type="checkbox"],
+body.options-general-php .wrap > form input[type="radio"],
+body.options-writing-php .wrap > form input[type="checkbox"],
+body.options-writing-php .wrap > form input[type="radio"],
+body.options-reading-php .wrap > form input[type="checkbox"],
+body.options-reading-php .wrap > form input[type="radio"],
+body.options-discussion-php .wrap > form input[type="checkbox"],
+body.options-discussion-php .wrap > form input[type="radio"],
+body.options-media-php .wrap > form input[type="checkbox"],
+body.options-media-php .wrap > form input[type="radio"],
+body.options-permalink-php .wrap > form input[type="checkbox"],
+body.options-permalink-php .wrap > form input[type="radio"] {
+  border: 2px solid #6c7781;
+  margin-right: 8px;
+  transition: none;
+}
+
+body.options-general-php .wrap > form input[type="checkbox"]:focus,
+body.options-general-php .wrap > form input[type="radio"]:focus,
+body.options-writing-php .wrap > form input[type="checkbox"]:focus,
+body.options-writing-php .wrap > form input[type="radio"]:focus,
+body.options-reading-php .wrap > form input[type="checkbox"]:focus,
+body.options-reading-php .wrap > form input[type="radio"]:focus,
+body.options-discussion-php .wrap > form input[type="checkbox"]:focus,
+body.options-discussion-php .wrap > form input[type="radio"]:focus,
+body.options-media-php .wrap > form input[type="checkbox"]:focus,
+body.options-media-php .wrap > form input[type="radio"]:focus,
+body.options-permalink-php .wrap > form input[type="checkbox"]:focus,
+body.options-permalink-php .wrap > form input[type="radio"]:focus {
+  border-color: #6c7781;
+  box-shadow: 0 0 0 1px #6c7781;
+}
+
+body.options-general-php .wrap > form input[type="checkbox"]:checked,
+body.options-general-php .wrap > form input[type="radio"]:checked,
+body.options-writing-php .wrap > form input[type="checkbox"]:checked,
+body.options-writing-php .wrap > form input[type="radio"]:checked,
+body.options-reading-php .wrap > form input[type="checkbox"]:checked,
+body.options-reading-php .wrap > form input[type="radio"]:checked,
+body.options-discussion-php .wrap > form input[type="checkbox"]:checked,
+body.options-discussion-php .wrap > form input[type="radio"]:checked,
+body.options-media-php .wrap > form input[type="checkbox"]:checked,
+body.options-media-php .wrap > form input[type="radio"]:checked,
+body.options-permalink-php .wrap > form input[type="checkbox"]:checked,
+body.options-permalink-php .wrap > form input[type="radio"]:checked {
+  background: #11a0d2;
+  border-color: #11a0d2;
+}
+
+body.options-general-php .wrap > form input[type="checkbox"]:checked:focus,
+body.options-general-php .wrap > form input[type="radio"]:checked:focus,
+body.options-writing-php .wrap > form input[type="checkbox"]:checked:focus,
+body.options-writing-php .wrap > form input[type="radio"]:checked:focus,
+body.options-reading-php .wrap > form input[type="checkbox"]:checked:focus,
+body.options-reading-php .wrap > form input[type="radio"]:checked:focus,
+body.options-discussion-php .wrap > form input[type="checkbox"]:checked:focus,
+body.options-discussion-php .wrap > form input[type="radio"]:checked:focus,
+body.options-media-php .wrap > form input[type="checkbox"]:checked:focus,
+body.options-media-php .wrap > form input[type="radio"]:checked:focus,
+body.options-permalink-php .wrap > form input[type="checkbox"]:checked:focus,
+body.options-permalink-php .wrap > form input[type="radio"]:checked:focus {
+  box-shadow: 0 0 0 2px #555d66;
+}
+
+body.options-general-php .wrap > form input[type="checkbox"],
+body.options-writing-php .wrap > form input[type="checkbox"],
+body.options-reading-php .wrap > form input[type="checkbox"],
+body.options-discussion-php .wrap > form input[type="checkbox"],
+body.options-media-php .wrap > form input[type="checkbox"],
+body.options-permalink-php .wrap > form input[type="checkbox"] {
+  border-radius: 4px;
+}
+
+body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+body.options-writing-php .wrap > form input[type="checkbox"]:checked::before,
+body.options-writing-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+body.options-reading-php .wrap > form input[type="checkbox"]:checked::before,
+body.options-reading-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+body.options-discussion-php .wrap > form input[type="checkbox"]:checked::before,
+body.options-discussion-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
+body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
+body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
+  margin: -3px -5px;
+  color: white;
+}
+
+@media all and (min-width: 782px) {
+  body.options-general-php .wrap > form input[type="checkbox"]:checked::before, body.options-general-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-writing-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-writing-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-reading-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-reading-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-discussion-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-discussion-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-media-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-media-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before,
+  body.options-permalink-php .wrap > form input[type="checkbox"]:checked::before,
+  body.options-permalink-php .wrap > form input[type="checkbox"][aria-checked="mixed"]::before {
+    margin: -4px 0 0 -5px;
+  }
+}
+
+body.options-general-php .wrap > form input[type="radio"],
+body.options-writing-php .wrap > form input[type="radio"],
+body.options-reading-php .wrap > form input[type="radio"],
+body.options-discussion-php .wrap > form input[type="radio"],
+body.options-media-php .wrap > form input[type="radio"],
+body.options-permalink-php .wrap > form input[type="radio"] {
+  border-radius: 8px;
+}
+
+body.options-general-php .wrap > form input[type="radio"]:checked::before,
+body.options-writing-php .wrap > form input[type="radio"]:checked::before,
+body.options-reading-php .wrap > form input[type="radio"]:checked::before,
+body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
+body.options-media-php .wrap > form input[type="radio"]:checked::before,
+body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
+  margin: 6px 0 0 6px;
+  background-color: white;
+}
+
+@media all and (min-width: 782px) {
+  body.options-general-php .wrap > form input[type="radio"]:checked::before,
+  body.options-writing-php .wrap > form input[type="radio"]:checked::before,
+  body.options-reading-php .wrap > form input[type="radio"]:checked::before,
+  body.options-discussion-php .wrap > form input[type="radio"]:checked::before,
+  body.options-media-php .wrap > form input[type="radio"]:checked::before,
+  body.options-permalink-php .wrap > form input[type="radio"]:checked::before {
+    margin: 3px 0 0 3px;
+  }
+}
+
+body.options-general-php .wrap > form select,
+body.options-writing-php .wrap > form select,
+body.options-reading-php .wrap > form select,
+body.options-discussion-php .wrap > form select,
+body.options-media-php .wrap > form select,
+body.options-permalink-php .wrap > form select {
+  -webkit-appearance: none;
+  background: url("../assets/dropdown-arrow.svg") center right no-repeat;
+  padding: 4px 32px 4px 10px;
+  height: auto;
+  box-shadow: 0 0 0 transparent;
+  transition: box-shadow 0.1s linear;
+  border-radius: 4px;
+  border: 1px solid #8d96a0;
+  font-size: 13px;
+}
+
+body.options-general-php .wrap > form select:disabled,
+body.options-writing-php .wrap > form select:disabled,
+body.options-reading-php .wrap > form select:disabled,
+body.options-discussion-php .wrap > form select:disabled,
+body.options-media-php .wrap > form select:disabled,
+body.options-permalink-php .wrap > form select:disabled {
+  border: 1px solid #ccd0d4;
+}
+
+body.options-general-php .wrap > form select:not(:disabled):hover,
+body.options-writing-php .wrap > form select:not(:disabled):hover,
+body.options-reading-php .wrap > form select:not(:disabled):hover,
+body.options-discussion-php .wrap > form select:not(:disabled):hover,
+body.options-media-php .wrap > form select:not(:disabled):hover,
+body.options-permalink-php .wrap > form select:not(:disabled):hover {
+  cursor: pointer;
+  background-color: #fafafa;
+  border-color: #999;
+  box-shadow: inset 0 -1px 0 #999;
+  color: #23282d;
+}
+
+body.options-general-php .wrap > form input[type="submit"].button-primary,
+body.options-writing-php .wrap > form input[type="submit"].button-primary,
+body.options-reading-php .wrap > form input[type="submit"].button-primary,
+body.options-discussion-php .wrap > form input[type="submit"].button-primary,
+body.options-media-php .wrap > form input[type="submit"].button-primary,
+body.options-permalink-php .wrap > form input[type="submit"].button-primary {
+  padding: 6px 12px;
+  height: auto;
+}
+
+body.options-writing-php #default_post_format {
+  padding-right: 32px;
+}
+
+body.options-writing-php #mailserver_url {
+  width: 25em;
+}
+
+body.options-writing-php #mailserver_url + label {
+  margin-left: 12px;
+}
+
+body.options-writing-php #mailserver_port {
+  width: 50px;
+}
+
+body.options-permalink-php code {
+  display: inline-block;
+  margin-top: 4px;
+}
+
+body.options-permalink-php p > code {
+  font-size: 12px;
+}
+
+body.options-permalink-php #permalink_structure {
+  margin-top: 16px;
+  margin-bottom: 8px;
+}

--- a/index.php
+++ b/index.php
@@ -22,6 +22,7 @@ class DesignExperiments {
 	 */
 	private $design_experiments = array(
 		array( 'default', 'Default plugin stylesheet', 'https://github.com/WordPress/design-experiments' ),
+		array( 'gutenberg-form-fields', 'Gutenberg-like forms' ),
 
 		// To enqueue a new stylesheet, add a line above using the example here as a guide: 
 		// array( 'stylesheet', 'Experiment title', 'url/to/experiment' ),

--- a/sass/gutenberg-form-fields.scss
+++ b/sass/gutenberg-form-fields.scss
@@ -1,6 +1,8 @@
-/*
- * Gutenberg Forms
- */
+/*{
+	"title": "Gutenberg Form Fields",
+	"details": "An experiment to see how Gutenberg form field styles might look in WP-Admin.",
+	"pr": "https://github.com/WordPress/design-experiments/pull/5"
+}*/
 
 body.options-general-php,
 body.options-writing-php,

--- a/sass/gutenberg-form-fields.scss
+++ b/sass/gutenberg-form-fields.scss
@@ -1,7 +1,7 @@
 /*
-	Title: Gutenberg Form Fields
-	Description: An experiment to see how Gutenberg form field styles might look in WP-Admin.
-	PR: https://github.com/WordPress/design-experiments/pull/5
+Title: Gutenberg Form Fields
+Description: An experiment to see how Gutenberg form field styles might look in WP-Admin.
+PR: https://github.com/WordPress/design-experiments/pull/5
 */
 
 body.options-general-php,

--- a/sass/gutenberg-form-fields.scss
+++ b/sass/gutenberg-form-fields.scss
@@ -1,0 +1,187 @@
+/*
+ * Gutenberg Forms
+ */
+
+body.options-general-php,
+body.options-writing-php,
+body.options-reading-php,
+body.options-discussion-php,
+body.options-media-php,
+body.options-permalink-php {
+ 	background: white;
+
+ 	.wrap > h1 {
+ 		max-width: 500px;
+ 		margin: 64px auto 0;
+ 	}
+
+ 	.wrap > form {
+ 		max-width: 500px;
+ 		margin: 0 auto;
+
+ 		tr {
+ 			flex-direction: column;
+			display: flex;
+ 		}
+
+ 		td {
+ 			padding: 0;
+ 		}
+
+ 		h2 {
+ 			margin-top: 48px;
+ 		}
+
+ 		.form-table, 
+ 		.form-table td, 
+ 		.form-table td p, 
+ 		.form-table th {
+ 			font-size: 13px;
+ 		}
+
+ 		.form-table th {
+ 			padding-bottom: 8px;
+ 			font-weight: normal;
+ 		}
+
+ 		input[type="text"],
+ 		input[type="url"],
+ 		input[type="email"],
+ 		input[type="number"] {
+ 			width: 100%;
+			max-width: 100%;
+			padding: 10px;
+			min-height: 24px;
+			background: inherit;
+ 			font-size: 13px;
+			color: #23282d;
+			box-shadow: none;
+			transition: box-shadow 0.1s linear;
+			border-radius: 4px;
+			border: 1px solid #8d96a0;
+
+			&:focus {
+				color: #191e23;
+				border-color: #007cba;
+				box-shadow: 0 0 0 1px #007cba;
+			}
+ 		}
+
+ 		input[type="number"].small-text {
+ 			width: 65px;
+ 		}
+
+ 		input[type="checkbox"],
+		input[type="radio"] {
+			border: 2px solid #6c7781;
+			margin-right: 8px;
+			transition: none;
+
+			&:focus {
+				border-color: #6c7781;
+				box-shadow: 0 0 0 1px #6c7781;
+			}
+
+			&:checked {
+				background: #11a0d2;
+				border-color: #11a0d2;
+			}
+
+			&:checked:focus {
+				box-shadow: 0 0 0 2px #555d66;
+			}
+		}
+
+		input[type="checkbox"] {
+			border-radius: 4px;
+
+			&:checked::before,
+			&[aria-checked="mixed"]::before {
+				margin: -3px -5px;
+				color: white;
+
+				@media all and (min-width: 782px) {
+					margin: -4px 0 0 -5px;
+				}
+			}
+		}
+
+		input[type="radio"] {
+			border-radius: 8px;
+
+			&:checked::before {
+				margin: 6px 0 0 6px;
+				background-color: white;
+
+				@media all and (min-width: 782px) {
+					margin: 3px 0 0 3px;
+				}
+			}
+		}
+
+		select {
+			-webkit-appearance: none;
+			background: url( '../assets/dropdown-arrow.svg' ) center right no-repeat;
+			padding: 4px 32px 4px 10px;
+			height: auto;
+			box-shadow: 0 0 0 transparent;
+			transition: box-shadow 0.1s linear;
+			border-radius: 4px;
+			border: 1px solid #8d96a0;
+			font-size: 13px;
+
+			&:disabled {
+				border: 1px solid #ccd0d4;
+			}
+
+			&:not(:disabled):hover {
+				cursor: pointer;
+				background-color: #fafafa;
+				border-color: #999;
+				box-shadow: inset 0 -1px 0 #999;
+				color: #23282d;
+			}
+		}
+
+		input[type="submit"].button-primary {
+			padding: 6px 12px;
+			height: auto;
+		}
+	}
+}
+
+body.options-writing-php {
+
+ 	#default_post_format {
+ 		padding-right: 32px;
+ 	}
+
+ 	#mailserver_url {
+ 		width: 25em;
+
+ 		+ label {
+ 			margin-left: 12px;
+ 		}
+ 	}
+
+ 	#mailserver_port {
+ 		width: 50px;
+ 	}
+}
+
+body.options-permalink-php {
+	
+	code {
+		display: inline-block;
+		margin-top: 4px;
+	}
+
+	p > code {
+		font-size: 12px;
+	}
+
+	#permalink_structure {
+		margin-top: 16px;
+		margin-bottom: 8px;
+	}
+}

--- a/sass/gutenberg-form-fields.scss
+++ b/sass/gutenberg-form-fields.scss
@@ -1,8 +1,8 @@
-/*{
-	"title": "Gutenberg Form Fields",
-	"details": "An experiment to see how Gutenberg form field styles might look in WP-Admin.",
-	"pr": "https://github.com/WordPress/design-experiments/pull/5"
-}*/
+/*
+	Title: Gutenberg Form Fields
+	Description: An experiment to see how Gutenberg form field styles might look in WP-Admin.
+	PR: https://github.com/WordPress/design-experiments/pull/5
+*/
 
 body.options-general-php,
 body.options-writing-php,


### PR DESCRIPTION
In this PR, I've ported over a bunch of the Gutenberg form field styles to see how they might look in WP-Admin. To test, make sure this experiment is active in `Settings > Design Experiments`, and then visit any of the standard pages under Settings (except for `Settings > Privacy` — I left that one out for now because the page structure is a little different). 

There are a few things to note: 

- I used a white background to get across the Gutenberg feel a bit more. 
- I limited the forms to 500px wide, to avoid super-long line lengths. I also pushed most text fields to 100% width. 
- I aggressively stacked all the form fields under their labels. We probably don't actually want to do this, but most of the form fields in Gutenberg are stacked that way for now. 

It's a little imperfect (it's an experiment!) but in general things feel pretty good to me! I like that it feels more analogous to Gutenberg. 

![wordpress test_wp-admin_options-general php](https://user-images.githubusercontent.com/1202812/57939397-4933bb80-7898-11e9-9e28-40044b0638ec.png)

![wordpress test_wp-admin_options-reading php](https://user-images.githubusercontent.com/1202812/57939398-4933bb80-7898-11e9-8f47-425e4480274e.png)

![wordpress test_wp-admin_options-writing php](https://user-images.githubusercontent.com/1202812/57939399-4933bb80-7898-11e9-9e96-1b15b2892e64.png)