### PR TITLE
Cleanup, make labels clickable, simplify

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,65 +10,54 @@
 
 class DesignExperiments {
 
+	/**
+	 * List of all CSS files
+	 */
+	private $design_experiment_css_files;
+
+	private $meta_data = array();
+
 	function __construct() {
-		
+
 		// Generate a list of all CSS files
-		$this->design_experiment_css_files = glob( 
-			plugin_dir_path( __FILE__ ) . 'css/*.css'
-		);
-		
-		$this->meta_data =
-			 $this->get_design_experiment_meta_data();
+		$this->design_experiment_css_files = glob( plugin_dir_path( __FILE__ ) . 'css/*.css' );
+
+		$this->get_design_experiment_meta_data();
 
 		// Add admin actions
 		add_action( 'admin_menu', array( $this, 'design_experiments_add_settings_page' ) );
 		add_action( 'admin_init', array( $this, 'design_experiments_settings' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'design_experiments_enqueue_stylesheets' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'design_experiments_enqueue_stylesheets' ), 100 );
 	}
-
 
 	/**
 	* Gets the meta data from each design experiment.
 	* return array $meta_data each experiment with its meta data.
 	*/
 	private function get_design_experiment_meta_data() {
-		$meta_data = [];
-		foreach ($this->design_experiment_css_files as $key => $file) {
-			preg_match(
-				'/^\/\*(\{.*?\})\*\//ism',
-				file_get_contents( 
-					$file 
-				),
-				$data
-			);
-			if ( ! empty( $data[1] ) ) {
-				$meta_data[basename($file, '.css')] = json_decode($data[1]);
+		foreach ( $this->design_experiment_css_files as $file ) {
+			$file_content = file_get_contents( $file );
+
+			if ( preg_match( '/^\/\*(\{.*?\})\*\//ism', $file_content, $data ) && ! empty( $data[1] ) ) {
+				$name = basename( $file, '.css' );
+				$this->meta_data[ $name ] = json_decode( $data[1] );
 			}
 		}
-		return $meta_data;
 	}
-
-
-	/**
-	 * Define a list of all CSS files
-	 */
-	private $design_experiment_css_files;
-
 
 	/**
 	 * Set up a WP-Admin page for managing turning on and off plugin features.
 	 */
 	function design_experiments_add_settings_page() {
-		add_options_page('Design Experiments', 'Design Experiments', 'manage_options', 'design-experiments', array( $this, 'design_experiments_settings_page' ) );
+		add_options_page( 'Design Experiments', 'Design Experiments', 'manage_options', 'design-experiments', array( $this, 'design_experiments_settings_page' ) );
 	}
-
 
 	/**
 	 * Register settings for the WP-Admin page.
 	 */
 	function design_experiments_settings() {
 		$design_setting_args = array(
-			'type' => 'string', 
+			'type' => 'string',
 			'default' => 'default',
 		);
 		register_setting( 'design-experiments-settings', 'design-experiments-setting', $design_setting_args );
@@ -79,26 +68,14 @@ class DesignExperiments {
 	 * Fetch experiment title from the CSS file.
 	 */
 	private function get_title( $experiment_name ) {
-		
-		$default_title = ucfirst( str_replace( '-', ' ', $experiment_name ) );
-		
-		if ( ! array_key_exists( $experiment_name, $this->meta_data ) ) {
-			return $default_title;
+
+		if ( array_key_exists( $experiment_name, $this->meta_data ) && ! empty( $this->meta_data[ $experiment_name ]->title ) ) {
+			$title = $this->meta_data[ $experiment_name ]->title;
+		} else {
+			$title = ucfirst( str_replace( '-', ' ', $experiment_name ) );
 		}
-		
-		$experiment_meta_data = $this->meta_data[$experiment_name];
-		$experiment_has_meta_data = array_key_exists( 
-			$experiment_name, $this->meta_data
-		);
-		$meta_data_has_title = ! empty( $experiment_meta_data->title );
-		
-		if ( $experiment_has_meta_data && $meta_data_has_title ) {
-			return esc_html( 
-				$experiment_meta_data->title
-			);
-		}
-		
-		return $default_title;
+
+		return esc_html( $title );
 	}
 
 
@@ -111,22 +88,18 @@ class DesignExperiments {
 			return false;
 		}
 
-		$experiment_meta_data = $this->meta_data[$experiment_name];
+		$experiment_meta = $this->meta_data[ $experiment_name ];
 
-		if ( ! empty( $experiment_meta_data->details ) ) {
+		if ( ! empty( $experiment_meta->details ) ) {
 			?>
-			<p>
-				<?php echo esc_html( 
-					$experiment_meta_data->details
-				); ?>
-			</p>
+			<p><?php echo esc_html( $experiment_meta->details ); ?></p>
 			<?php
 		}
-		
-		if ( ! empty( $experiment_meta_data->pr ) ) {
+
+		if ( ! empty( $experiment_meta->pr ) ) {
 			?>
 			<p>
-				<a href="<?php echo $experiment_meta_data->pr; ?>"><?php _e( 'Details' ); ?></a>
+				<a href="<?php echo esc_url( $experiment_meta->pr ); ?>"><?php _e( 'Details', 'design-experiments' ); ?></a>
 			</p>
 			<?php
 		}
@@ -145,25 +118,37 @@ class DesignExperiments {
 			<?php settings_fields( 'design-experiments-settings' ); ?>
 			<?php do_settings_sections( 'design-experiments-settings' ); ?>
 
-				<table class="form-table" style="width: auto;">
-					<?php foreach ( $this->design_experiment_css_files as $css_file ) {
-						$experiment_name = basename( $css_file, '.css' ); 
-						$experiment_title = $this->get_title( $experiment_name ); ?>
-						<tr valign="top">
-							<td style="vertical-align: top;display: table-cell;">
-								<input name="design-experiments-setting" type="radio" value="<?php echo esc_attr( $experiment_name ); ?>" <?php checked( $experiment_name, get_option( 'design-experiments-setting' ) ); ?> />
-							</td>
-							<td style="display: table-cell;">
-								<label for="design-experiments-setting" style="font-weight: bold">
-									<?php echo esc_html( $experiment_title ); ?>
-								</label>
-								<?php $this->output_meta_data(
-									$experiment_name
-								); ?>
-							</td>
-						</tr>
-					<?php } ?>
-				</table>
+			<table class="form-table" style="width: auto;">
+			<?php
+
+			foreach ( $this->design_experiment_css_files as $key => $css_file ) {
+				$experiment_name = basename( $css_file, '.css' );
+				$experiment_title = $this->get_title( $experiment_name );
+				$id = esc_attr( "design-experiments-setting-{$key}" );
+
+				?>
+				<tr>
+					<td style="vertical-align: top;">
+						<input
+							type="radio"
+							id="<?php echo $id; ?>"
+							name="design-experiments-setting"
+							value="<?php echo esc_attr( $experiment_name ); ?>"
+							<?php checked( $experiment_name, get_option( 'design-experiments-setting' ) ); ?>
+						/>
+					</td>
+					<td>
+						<label for="<?php echo $id; ?>" style="font-weight: bold">
+							<?php echo esc_html( $experiment_title ); ?>
+						</label>
+						<?php $this->output_meta_data( $experiment_name ); ?>
+					</td>
+				</tr>
+				<?php
+			}
+
+			?>
+			</table>
 
 			<?php submit_button(); ?>
 		</form>
@@ -176,16 +161,25 @@ class DesignExperiments {
 	 */
 	function design_experiments_enqueue_stylesheets() {
 
+		$option = get_option( 'design-experiments-setting' );
+
 		foreach ( $this->design_experiment_css_files as $css_file ) {
 			$experiment_name = basename( $css_file, '.css' );
-			$experiment_url = plugins_url( 'css/' . basename( $css_file ), __FILE__ );
 
-			if ( get_option( 'design-experiments-setting' ) == $experiment_name ) {
-				wp_register_style( $experiment_name , $experiment_url, false, '1.0.0' );
+			if ( $option === $experiment_name ) {
+				$experiment_url = plugins_url( 'css/' . basename( $css_file ), __FILE__ );
+
+				// Auto-bust cache here, perhaps?
+				// $mtime = @filemtime( $css_file );
+				// $version = $mtime ? $mtime : time();
+
+				$version = '1.0.0';
+
+				wp_register_style( $experiment_name , $experiment_url, false, $version );
 				wp_enqueue_style( $experiment_name );
+				break;
 			}
 		}
-
 	}
 
 }


### PR DESCRIPTION
Makes the labels on the settings screen clickable. Also some white space and code cleanup and simplification. 

Wondering if it needs to refresh cache when registering the stylesheets, maybe better especially when editing one (left some example code commented out).