### PR TITLE
Add a quick dark mode using the difference blend mode

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -52,3 +52,13 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu > li.current > a.curre
   z-index: 500;
   pointer-events: none;
 }
+
+img,
+.wp-block-cover {
+  filter: invert(1);
+}
+
+.media-modal img,
+.theme-overlay img {
+  filter: none;
+}

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -1,0 +1,53 @@
+/*
+Title: Dark Mode
+Description: Uses the 'difference' blending mode to provide a quick and messy dark mode.
+*/
+#wpadminbar,
+#adminmenuwrap,
+#adminmenu,
+#adminmenuback {
+  background-color: black;
+}
+
+#adminmenu .wp-has-current-submenu .wp-submenu,
+#adminmenu .wp-has-current-submenu .wp-submenu.sub-open,
+#adminmenu .wp-has-current-submenu.opensub .wp-submenu,
+#adminmenu a.wp-has-current-submenu:focus + .wp-submenu,
+.no-js li.wp-has-current-submenu:hover .wp-submenu {
+  background-color: #1a1a1a;
+}
+
+#adminmenu .wp-has-current-submenu .wp-submenu .wp-submenu-head,
+#adminmenu .wp-menu-arrow, #adminmenu .wp-menu-arrow div,
+#adminmenu li.current a.menu-top, #adminmenu li.wp-has-current-submenu a.wp-has-current-submenu,
+.folded #adminmenu li.current.menu-top,
+.folded #adminmenu li.wp-has-current-submenu {
+  background-color: #e07848;
+}
+
+ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu > li.current > a.current:after {
+  display: none;
+}
+
+#wpbody {
+  position: relative;
+}
+
+#wpcontent {
+  background-color: white;
+}
+
+#wpbody::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -20px;
+  right: 0;
+  min-height: 100vh;
+  background-color: white;
+  mix-blend-mode: difference;
+  z-index: 500;
+  pointer-events: none;
+}

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -34,6 +34,7 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu > li.current > a.curre
   position: relative;
 }
 
+body,
 #wpcontent {
   background-color: white;
 }

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -1,6 +1,7 @@
 /*
 Title: Dark Mode
 Description: Uses the 'difference' blending mode to provide a quick and messy dark mode.
+PR: https://github.com/WordPress/design-experiments/pull/8
 */
 #wpadminbar,
 #adminmenuwrap,

--- a/sass/dark-mode.scss
+++ b/sass/dark-mode.scss
@@ -1,6 +1,7 @@
 /*
 Title: Dark Mode
 Description: Uses the 'difference' blending mode to provide a quick and messy dark mode.
+PR: https://github.com/WordPress/design-experiments/pull/8
 */
 
 #wpadminbar,

--- a/sass/dark-mode.scss
+++ b/sass/dark-mode.scss
@@ -35,6 +35,7 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 	position: relative;
 }
 
+body,
 #wpcontent {
 	background-color: white;
 }

--- a/sass/dark-mode.scss
+++ b/sass/dark-mode.scss
@@ -1,0 +1,54 @@
+/*
+Title: Dark Mode
+Description: Uses the 'difference' blending mode to provide a quick and messy dark mode.
+*/
+
+#wpadminbar,
+#adminmenuwrap,
+#adminmenu,
+#adminmenuback {
+	background-color: black;
+}
+
+#adminmenu .wp-has-current-submenu .wp-submenu, 
+#adminmenu .wp-has-current-submenu .wp-submenu.sub-open, 
+#adminmenu .wp-has-current-submenu.opensub .wp-submenu, 
+#adminmenu a.wp-has-current-submenu:focus+.wp-submenu, 
+.no-js li.wp-has-current-submenu:hover .wp-submenu {
+	background-color: rgb(26, 26, 26);
+}
+
+#adminmenu .wp-has-current-submenu .wp-submenu .wp-submenu-head, 
+#adminmenu .wp-menu-arrow, #adminmenu .wp-menu-arrow div, 
+#adminmenu li.current a.menu-top, #adminmenu li.wp-has-current-submenu a.wp-has-current-submenu, 
+.folded #adminmenu li.current.menu-top, 
+.folded #adminmenu li.wp-has-current-submenu {
+	background-color: #e07848
+}
+
+ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:after {
+	display: none;
+}
+
+#wpbody {
+	position: relative;
+}
+
+#wpcontent {
+	background-color: white;
+}
+
+#wpbody::after {
+	content: "";
+	display: block;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: -20px;
+	right: 0;
+	min-height: 100vh;
+	background-color: white;
+	mix-blend-mode: difference;
+	z-index: 500;
+	pointer-events: none;
+}

--- a/sass/dark-mode.scss
+++ b/sass/dark-mode.scss
@@ -53,3 +53,15 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 	z-index: 500;
 	pointer-events: none;
 }
+
+// Try re-inverting images. 
+img, 
+.wp-block-cover {
+	filter: invert(1);
+}
+
+// But not in our overlays.
+.media-modal img,
+.theme-overlay img {
+	filter: none;
+}


### PR DESCRIPTION
Inspired by [a recent article](https://dev.wgao19.cc/2019-05-04__sun-moon-blending-mode/) about using `mix-blend-mode` for a quick dark mode implementation, I decided to see how that would look applied to WP-Admin. Here's the result: 

![dark-mode](https://user-images.githubusercontent.com/1202812/58499711-b83dc980-814e-11e9-9564-b80d3bd0a715.gif)

This is kind of fun to try out, but doesn't seem entirely viable. Images are an inverted mess at the moment (I couldn't get the `isolation: isolate` exception working here). It also requires a fairly recent browser that is not Internet Explorer. 