### PR TITLE
Try larger font sizes throughout WP-Admin

### DIFF
--- a/css/larger-font-size.css
+++ b/css/larger-font-size.css
@@ -4,7 +4,7 @@ Description: Trying some larger font sizes in WP-Admin.
 */
 /*
  * Body Small
- * 14px
+ * 0.875rem = 14px
  */
 #adminmenu .wp-submenu a,
 .postbox .inside,
@@ -36,12 +36,12 @@ span.description,
 .theme-overlay .theme-version,
 .theme-overlay .theme-tags,
 .notice p {
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 /*
  * Body
- * 16px
+ * 1rem = 16px
  */
 body,
 p,
@@ -65,32 +65,32 @@ td.plugin-title strong,
 #published-posts a,
 .theme-overlay .theme-description,
 .settings_page_design-experiments label {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .row-title {
-  font-size: 16px !important;
+  font-size: 1rem !important;
 }
 
 /*
  * Display Small
- * 20px
+ * 1.25rem = 20px
  */
 h2,
 h3 {
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: normal;
 }
 
 /*
  * Display Medium
- * 24px
+ * 1.5rem = 24px
  */
 .postbox .inside h2,
 .wrap [class$=icon32] + h2,
 .wrap h1,
 .wrap > h2:first-child {
-  font-size: 24px;
+  font-size: 1.5rem;
 }
 
 /*

--- a/css/larger-font-size.css
+++ b/css/larger-font-size.css
@@ -1,6 +1,7 @@
 /*
 Title: Larger Font Sizes
 Description: Trying some larger font sizes in WP-Admin.
+PR: https://github.com/WordPress/design-experiments/pull/9
 */
 /*
  * Body Small

--- a/css/larger-font-size.css
+++ b/css/larger-font-size.css
@@ -1,0 +1,101 @@
+/*
+Title: Larger Font Sizes
+Description: Trying some larger font sizes in WP-Admin.
+*/
+/*
+ * Body Small
+ * 14px
+ */
+#adminmenu .wp-submenu a,
+.postbox .inside,
+.postbox p,
+.form-table,
+.form-table td,
+.form-table td p,
+.subsubsub,
+.widefat td,
+.widefat td ol,
+.widefat td p,
+.widefat td ul,
+.widefat tfoot td,
+.widefat th,
+.widefat thead td,
+.row-actions,
+.wp-core-ui .button,
+.wp-core-ui .button-primary,
+.wp-core-ui .button-secondary,
+a.rsswidget,
+.form-wrap p,
+p.description,
+p.help,
+span.description,
+#available-widgets .widget .widget-description,
+.widget-title h3,
+.widget-title h4,
+.theme-overlay .current-label,
+.theme-overlay .theme-version,
+.theme-overlay .theme-tags,
+.notice p {
+  font-size: 14px;
+}
+
+/*
+ * Body
+ * 16px
+ */
+body,
+p,
+input,
+select,
+textarea,
+.wp-filter,
+.metabox-holder .postbox > h3,
+.metabox-holder .stuffbox > h3,
+.metabox-holder h2.hndle,
+.metabox-holder h3.hndle,
+.form-table th,
+td.column-title strong,
+td.plugin-title strong,
+.column-username strong a,
+#adminmenu .wp-submenu-head,
+#adminmenu a.menu-top,
+#wpadminbar *,
+.community-events .event-title,
+#dashboard_quick_press .draft-title,
+#published-posts a,
+.theme-overlay .theme-description,
+.settings_page_design-experiments label {
+  font-size: 16px;
+}
+
+.row-title {
+  font-size: 16px !important;
+}
+
+/*
+ * Display Small
+ * 20px
+ */
+h2,
+h3 {
+  font-size: 20px;
+  font-weight: normal;
+}
+
+/*
+ * Display Medium
+ * 24px
+ */
+.postbox .inside h2,
+.wrap [class$=icon32] + h2,
+.wrap h1,
+.wrap > h2:first-child {
+  font-size: 24px;
+}
+
+/*
+ * Misc Updates
+ */
+.settings_page_design-experiments .form-table input[type=radio] {
+  margin-top: 0;
+}

--- a/sass/larger-font-size.scss
+++ b/sass/larger-font-size.scss
@@ -1,6 +1,7 @@
 /*
 Title: Larger Font Sizes
 Description: Trying some larger font sizes in WP-Admin.
+PR: https://github.com/WordPress/design-experiments/pull/9
 */
 
 

--- a/sass/larger-font-size.scss
+++ b/sass/larger-font-size.scss
@@ -6,7 +6,7 @@ Description: Trying some larger font sizes in WP-Admin.
 
 /*
  * Body Small
- * 14px
+ * 0.875rem = 14px
  */
 
 #adminmenu .wp-submenu a,
@@ -39,13 +39,13 @@ span.description,
 .theme-overlay .theme-version,
 .theme-overlay .theme-tags,
 .notice p {
-	font-size: 14px;
+	font-size: 0.875rem;
 }
 
 
 /*
  * Body
- * 16px
+ * 1rem = 16px
  */
 
 body,
@@ -70,35 +70,35 @@ td.plugin-title strong,
 #published-posts a,
 .theme-overlay .theme-description,
 .settings_page_design-experiments label {
-	font-size: 16px;
+	font-size: 1rem;
 }
 
 // This one has to override an existing !important. 😠
 .row-title {
-	font-size: 16px !important;
+	font-size: 1rem !important;
 }
 
 /*
  * Display Small
- * 20px
+ * 1.25rem = 20px
  */
 
 h2, 
 h3 {
-	font-size: 20px;
+	font-size: 1.25rem;
 	font-weight: normal;
 }
 
 /*
  * Display Medium
- * 24px
+ * 1.5rem = 24px
  */
 
 .postbox .inside h2, 
 .wrap [class$=icon32]+h2, 
 .wrap h1, 
 .wrap>h2:first-child {
-	font-size: 24px;
+	font-size: 1.5rem;
 }
 
 

--- a/sass/larger-font-size.scss
+++ b/sass/larger-font-size.scss
@@ -1,0 +1,112 @@
+/*
+Title: Larger Font Sizes
+Description: Trying some larger font sizes in WP-Admin.
+*/
+
+
+/*
+ * Body Small
+ * 14px
+ */
+
+#adminmenu .wp-submenu a,
+.postbox .inside,
+.postbox p,
+.form-table, 
+.form-table td, 
+.form-table td p, 
+.subsubsub,
+.widefat td, 
+.widefat td ol, 
+.widefat td p, 
+.widefat td ul,
+.widefat tfoot td, 
+.widefat th, 
+.widefat thead td,
+.row-actions,
+.wp-core-ui .button, 
+.wp-core-ui .button-primary, 
+.wp-core-ui .button-secondary,
+a.rsswidget,
+.form-wrap p, 
+p.description, 
+p.help, 
+span.description,
+#available-widgets .widget .widget-description,
+.widget-title h3, 
+.widget-title h4,
+.theme-overlay .current-label,
+.theme-overlay .theme-version,
+.theme-overlay .theme-tags,
+.notice p {
+	font-size: 14px;
+}
+
+
+/*
+ * Body
+ * 16px
+ */
+
+body,
+p,
+input, 
+select, 
+textarea,
+.wp-filter,
+.metabox-holder .postbox>h3, 
+.metabox-holder .stuffbox>h3, 
+.metabox-holder h2.hndle, 
+.metabox-holder h3.hndle,
+.form-table th,
+td.column-title strong, 
+td.plugin-title strong,
+.column-username strong a,
+#adminmenu .wp-submenu-head, 
+#adminmenu a.menu-top,
+#wpadminbar *,
+.community-events .event-title,
+#dashboard_quick_press .draft-title,
+#published-posts a,
+.theme-overlay .theme-description,
+.settings_page_design-experiments label {
+	font-size: 16px;
+}
+
+// This one has to override an existing !important. 😠
+.row-title {
+	font-size: 16px !important;
+}
+
+/*
+ * Display Small
+ * 20px
+ */
+
+h2, 
+h3 {
+	font-size: 20px;
+	font-weight: normal;
+}
+
+/*
+ * Display Medium
+ * 24px
+ */
+
+.postbox .inside h2, 
+.wrap [class$=icon32]+h2, 
+.wrap h1, 
+.wrap>h2:first-child {
+	font-size: 24px;
+}
+
+
+/*
+ * Misc Updates
+ */
+
+// Properly lines these up with the text.
+.settings_page_design-experiments .form-table input[type=radio] {
+	margin-top: 0;
+}


### PR DESCRIPTION
Taking a cue from some discussion in a #design channel meeting last week ([transcript](https://wordpress.slack.com/archives/C02S78ZAL/p1559153953111900) — registration required), I took a little bit of time to try out some larger font sizes throughout WP-Admin. For now, I used the following type scale: 

**Body Small** 0.875rem (~14px)
**Body** 1rem (~16px)
**Display Small** 1.25rem (~20px)
**Display Medium** 1.5rem (~24px)

I had a hard time figuring out the existing type scale for WP-Admin, since I found it using a _ton_ of pixel sizes: 11px, 12px, 13px, 14px, 15px, 16px, etc. Because of this, it wasn't easy to do a 1:1 swap for different sizes. Instead, I had to approximate hierarchy in many areas. To keep it simple, I just did a quick pass at this. 

In any case, here are some before/after screens. To get a better feel, I'd recommend trying this out though. 

---

**GIF**

![font-sizes](https://user-images.githubusercontent.com/1202812/58907523-6364fa80-86dc-11e9-87c7-e3ba7bd27a50.gif)

---

**Dashboard**

_Before_

![wordpress test_wp-admin_(iPad) (1)](https://user-images.githubusercontent.com/1202812/58907378-0b2df880-86dc-11e9-862e-88a7fe1148dc.png)

_After_

![wordpress test_wp-admin_(iPad)](https://user-images.githubusercontent.com/1202812/58907389-108b4300-86dc-11e9-80af-92a88b7a95c8.png)

---

**Posts**

_Before_

![wordpress test_wp-admin_edit php(iPad) (1)](https://user-images.githubusercontent.com/1202812/58907492-4fb99400-86dc-11e9-8cf9-93817c0fa65f.png)

_After_

![wordpress test_wp-admin_edit php(iPad)](https://user-images.githubusercontent.com/1202812/58907499-534d1b00-86dc-11e9-8583-44777a86c355.png)

---

**General Settings**

_Before_

![wordpress test_wp-admin_options-general php(iPad)](https://user-images.githubusercontent.com/1202812/58907446-30bb0200-86dc-11e9-9bca-cf774091817a.png)

_After_

![wordpress test_wp-admin_options-general php(iPad) (1)](https://user-images.githubusercontent.com/1202812/58907452-34e71f80-86dc-11e9-9768-fa9ffe30794d.png)
