### PR TITLE
Add a plugin readme file

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ An important disclaimer: This plugin is called experimental for a reason. It is 
 
 1. Upload the plugin files to the `/wp-content/plugins/plugin-name` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress
-3. Use the Settings->Design Experimentst screen to activate an experiment.
+3. Use the Settings->Design Experiments screen to activate an experiment.
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ A plugin for trying out design experiments in WP-Admin. Brought to you by the Wo
 
 == Description ==
 
-The Design Experiments plugin is a tool for prototyping designs within the context of WP-Admin. It contains a number of proof-of-concepts that the [WordPress Design Team](http://make.wordpress.org/design/) is exploring. 
+The Design Experiments plugin is a tool for prototyping designs within the context of WP-Admin. It contains a number of proof of concepts that the [WordPress Design Team](http://make.wordpress.org/design/) is exploring. 
 
 An important disclaimer: This plugin is called experimental for a reason. It is for testing concepts, and is not intended for use on a production site. These experiments may hide or visually break functionality in the admin area. Some of the experiments may break after a while, and will be removed from the plugin. Do not rely on this plugin for permanent changes to your site.
 
@@ -31,7 +31,7 @@ An important disclaimer: This plugin is called experimental for a reason. It is 
 
 = What do I do if an experiment appears broken? =
 
-These are rough proof-of-concepts, so some breakage is generally expected. If you'd like to follow up with the team who built the plugin though, you may [submit an issue on GitHub](https://github.com/WordPress/design-experiments/issues). 
+These are rough proof of concepts, so some breakage is generally expected. If you'd like to follow up with the team who built the plugin though, you may [submit an issue on GitHub](https://github.com/WordPress/design-experiments/issues). 
 
 = I have an idea for an experiment, how do I submit it? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ A plugin for trying out design experiments in WP-Admin. Brought to you by the Wo
 
 The Design Experiments plugin is a tool for prototyping designs within the context of WP-Admin. It contains a number of proof-of-concepts that the [WordPress Design Team](http://make.wordpress.org/design/) is exploring. 
 
-An important disclaimer: This plugin is called experimental for a reason. It is for testing concepts, and is not intended for use on a production site. These experiments may hide or visually break functionality in the admin area. Some of the experiments may break after a while, and will be removed from the plugin.
+An important disclaimer: This plugin is called experimental for a reason. It is for testing concepts, and is not intended for use on a production site. These experiments may hide or visually break functionality in the admin area. Some of the experiments may break after a while, and will be removed from the plugin. Do not rely on this plugin for permanent changes to your site.
 
 == Installation ==
 
@@ -35,4 +35,4 @@ These are rough proof-of-concepts, so some breakage is generally expected. If yo
 
 = I have an idea for an experiment, how do I submit it? =
 
-If you'd like to build your own experiment, or just submit an idea, you can do so by at [the plugin's GitHub page](https://github.com/WordPress/design-experiments). 
+There are instructions for submitting ideas and building your own experiments at [the plugin's GitHub page](https://github.com/WordPress/design-experiments). 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,7 @@
 === Design Experiments ===
 Contributors: wordpressdotorg, kjellr, karmatosed, mapk, azaozz, andraganescu, melchoyce, tinkerbelly
-Tags: design, experiments, 
+Tags: design, experiments
+Stable tag: trunk
 Requires at least: 4.6
 Tested up to: 5.2
 Requires PHP: 5.2.4

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Design Experiments ===
-Contributors: wordpressdotorg, kjellr, karmatosed, mapk, azaozz, andraganescu, melchoyce, tinkerbelly
+Contributors: wordpressdotorg, andraganescu, azaozz, karmatosed, kjellr, mapk, melchoyce, tinkerbelly
 Tags: design, experiments
 Stable tag: trunk
 Requires at least: 4.6

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,37 @@
+=== Design Experiments ===
+Contributors: wordpressdotorg, kjellr, karmatosed, mapk, azaozz, andraganescu, melchoyce, tinkerbelly
+Tags: design, experiments, 
+Requires at least: 4.6
+Tested up to: 5.2
+Requires PHP: 5.2.4
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A plugin for trying out design experiments in WP-Admin. Brought to you by the WordPress Design Team.
+
+== Description ==
+
+The Design Experiments plugin is a tool for prototyping designs within the context of WP-Admin. It contains a number of proof-of-concepts that the [WordPress Design Team](http://make.wordpress.org/design/) is exploring. 
+
+An important disclaimer: This plugin is called experimental for a reason. It is for testing concepts, and is not intended for use on a production site. These experiments may hide or visually break functionality in the admin area. Some of the experiments may break after a while, and will be removed from the plugin.
+
+== Installation ==
+
+1. Upload the plugin files to the `/wp-content/plugins/plugin-name` directory, or install the plugin through the WordPress plugins screen directly.
+2. Activate the plugin through the 'Plugins' screen in WordPress
+3. Use the Settings->Design Experimentst screen to activate an experiment.
+
+== Changelog ==
+
+= 1.0 =
+* Initial release. Includes experiments for larger font sizes, Gutenberg-style form fields, an updated header treatment throughout WP-Admin, and a dark mode.
+
+== Frequently Asked Questions ==
+
+= What do I do if an experiment appears broken? =
+
+These are rough proof-of-concepts, so some breakage is generally expected. If you'd like to follow up with the team who built the plugin though, you may [submit an issue on GitHub](https://github.com/WordPress/design-experiments/issues). 
+
+= I have an idea for an experiment, how do I submit it? =
+
+If you'd like to build your own experiment, or just submit an idea, you can do so by at [the plugin's GitHub page](https://github.com/WordPress/design-experiments). 


### PR DESCRIPTION
Follows the formatting and guidelines for [WordPress Plugin Directory readmes](https://wordpress.org/plugins/developers/#readme). 

Copy edits and suggestions are welcome! 