### PR TITLE
Try adding animated hovers to WP-Admin submenus

### DIFF
--- a/css/animated-menu-hovers.css
+++ b/css/animated-menu-hovers.css
@@ -1,0 +1,50 @@
+/*
+Title: Animated Menu Hovers
+Description: Trying Gutenberg's menu flyout animations in WP-Admin.
+*/
+/* Keyframes */
+@keyframes appear-animation {
+  from {
+    transform: translateY(-2em) scaleY(0) scaleX(0);
+  }
+  to {
+    transform: translateY(0%) scaleY(1) scaleX(1);
+  }
+}
+
+/* Animated Elements */
+#adminmenu a.wp-not-current-submenu.menu-top:focus + .wp-submenu,
+.js #adminmenu .opensub .wp-submenu,
+.js #adminmenu .sub-open,
+.menupop.hover .ab-sub-wrapper {
+  animation: appear-animation 0.1s cubic-bezier(0, 0, 0.2, 1) 0s;
+  animation-fill-mode: forwards;
+  transform-origin: top left;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #adminmenu a.wp-not-current-submenu.menu-top:focus + .wp-submenu,
+  .js #adminmenu .opensub .wp-submenu,
+  .js #adminmenu .sub-open,
+  .menupop.hover .ab-sub-wrapper {
+    animation-duration: 1ms;
+  }
+}
+
+#wp-admin-bar-my-account.menupop.hover .ab-sub-wrapper {
+  transform-origin: top right;
+}
+
+body.folded .adminmenuback,
+body.folded .adminmenuwrap {
+  animation: wide-animation 0.1s cubic-bezier(0, 0, 0.2, 1) 0s;
+  animation-fill-mode: forwards;
+  transform-origin: top left;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.folded .adminmenuback,
+  body.folded .adminmenuwrap {
+    animation-duration: 1ms;
+  }
+}

--- a/sass/animated-menu-hovers.scss
+++ b/sass/animated-menu-hovers.scss
@@ -1,0 +1,45 @@
+/*
+Title: Animated Menu Hovers
+Description: Trying Gutenberg's menu flyout animations in WP-Admin.
+*/
+
+/* Keyframes */
+
+@keyframes appear-animation {
+	from {
+		transform: translateY(-2em) scaleY(0) scaleX(0);
+	}
+	to {
+		transform: translateY(0%) scaleY(1) scaleX(1);
+	}
+}
+
+/* Animated Elements */
+
+#adminmenu a.wp-not-current-submenu.menu-top:focus+.wp-submenu, 
+.js #adminmenu .opensub .wp-submenu, 
+.js #adminmenu .sub-open,
+.menupop.hover .ab-sub-wrapper {
+	animation: appear-animation 0.1s cubic-bezier(0, 0, 0.2, 1) 0s;
+	animation-fill-mode: forwards;
+	transform-origin: top left;
+	
+	@media (prefers-reduced-motion: reduce) {
+		animation-duration: 1ms;
+	}
+}
+
+#wp-admin-bar-my-account.menupop.hover .ab-sub-wrapper {
+	transform-origin: top right;
+}
+
+body.folded .adminmenuback,
+body.folded .adminmenuwrap {
+	animation: wide-animation 0.1s cubic-bezier(0, 0, 0.2, 1) 0s;
+	animation-fill-mode: forwards;
+	transform-origin: top left;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation-duration: 1ms;
+	}
+}

--- a/sass/animated-menu-hovers.scss
+++ b/sass/animated-menu-hovers.scss
@@ -32,14 +32,3 @@ Description: Trying Gutenberg's menu flyout animations in WP-Admin.
 #wp-admin-bar-my-account.menupop.hover .ab-sub-wrapper {
 	transform-origin: top right;
 }
-
-body.folded .adminmenuback,
-body.folded .adminmenuwrap {
-	animation: wide-animation 0.1s cubic-bezier(0, 0, 0.2, 1) 0s;
-	animation-fill-mode: forwards;
-	transform-origin: top left;
-
-	@media (prefers-reduced-motion: reduce) {
-		animation-duration: 1ms;
-	}
-}


### PR DESCRIPTION
This is a relatively simple experiment. Currently, when you hover on parent menu items in WP-Admin, they just appear, with no animation at all.

This PR borrows the very short (`0.1s`) animation used for popover menus Gutenberg, and applies it to these submenus as they appear: 

![flyout](https://user-images.githubusercontent.com/1202812/61798787-f0cced00-adf7-11e9-9964-f94b3ec5d07f.gif)
_^ This has been slowed down so the GIF's framerate can capture it well_

This supports the [`prefers-reduce-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query, to respect the user's OS-level settings for animation. 