### PR TITLE
Add settings link to plugins page.

### DIFF
--- a/index.php
+++ b/index.php
@@ -30,6 +30,9 @@ class DesignExperiments {
 		add_action( 'admin_init', array( $this, 'design_experiments_settings' ) );
 		add_action( 'admin_notices', array( $this, 'design_experiments_admin_notice' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'design_experiments_enqueue_stylesheets' ), 100 );
+
+		// Filters
+		add_filter( 'plugin_action_links_design-experiments/index.php', array( $this, 'design_experiments_add_settings_link' ) );
 	}
 
 	/**
@@ -200,6 +203,15 @@ class DesignExperiments {
 			</div>
 			<?php 
 		}
+	}
+
+	/**
+	 * Include a link to the plugin settings on the main plugins page.
+	 */
+	function design_experiments_add_settings_link( $links ) {
+		$settings_link = '<a href="options-general.php?page=design-experiments">' . __( 'Settings' ) . '</a>';
+		array_push( $links, $settings_link );
+		return $links;
 	}
 
 }


### PR DESCRIPTION
This is a quick update to make the experiments a little more easy to access. It just adds a contextual "Settings" link on the plugins page.

**Before**

<img width="880" alt="Screen Shot 2019-09-09 at 9 48 12 AM" src="https://user-images.githubusercontent.com/1202812/64536349-f4083380-d2e6-11e9-9c82-3dfb64333895.png">

**After**

<img width="882" alt="Screen Shot 2019-09-09 at 9 47 31 AM" src="https://user-images.githubusercontent.com/1202812/64536314-e2bf2700-d2e6-11e9-81fd-c4aa5b513d2c.png">
